### PR TITLE
Support for aliases

### DIFF
--- a/auth0_api_settings.inc.json
+++ b/auth0_api_settings.inc.json
@@ -9,7 +9,12 @@
         "ldap_pass": "",
         "ldap_host": "",
         "mail_attribute": "",
-        "disabled_query": "employeeType=DISABLED"
+        "alias_attribute": "",
+        "disabled_query": "employeeType=DISABLED",
+        "ldap_domains": [
+            "example.com",
+            "example2.com"
+        ]
     },
     "proxy_config": {
         "use_proxy": "",

--- a/disable_deactivated_accounts.py
+++ b/disable_deactivated_accounts.py
@@ -68,12 +68,10 @@ def list_active_users(users):
 #    return [user for user in users if u'blocked' not in user or user[u'blocked'] != True]
 
 # this function returns the DN of the user that matches the given e-mail address
-def get_ldap_user_by_mail(conn, mail, attribute_type):
-    if attribute_type is "canonical":
-        mail_attribute = ldap_config['mail_attribute']
-    elif attribute_type is "alias":
-        mail_attribute = ldap_config['alias_attribute']
-    mail_query = '(%s=%s)' % (mail_attribute, mail)
+def get_ldap_user_by_mail(conn, mail):
+    mail_attribute = ldap_config['mail_attribute']
+    alias_attribute = ldap_config['alias_attribute']
+    mail_query = '(|(%s=%s)(%s=%s))' % (mail_attribute, mail, alias_attribute, mail)
     disabled_query = ldap_config['disabled_query']
     member = conn.search_s('dc=mozilla',
                            ldap.SCOPE_SUBTREE,
@@ -139,8 +137,7 @@ def main(prog_args=None):
         if id and email:
             for domain in ldap_config['ldap_domains']:
                 if domain in email:
-                    if get_ldap_user_by_mail(ldap_conn, email, "canonical") is not True\
-                            and get_ldap_user_by_mail(ldap_conn, email, "alias") is not True\
+                    if get_ldap_user_by_mail(ldap_conn, email) is not True\
                             and email not in disable_deactivated_accounts_config['exclusion_list']:
                         print "Disabling Auth0 for %s" % email
                         if not opt.debug:

--- a/disable_deactivated_accounts.py
+++ b/disable_deactivated_accounts.py
@@ -84,7 +84,7 @@ def get_ldap_user_by_mail(conn, mail):
                 return False
         except (IndexError, KeyError):
             return None
-    elif len(members) == 0:
+    elif len(member) == 0:
         return False
     else:
         print "Something went wrong and we got %i entries and expected 0 or 1" % len(member)

--- a/disable_deactivated_accounts.py
+++ b/disable_deactivated_accounts.py
@@ -135,18 +135,18 @@ def main(prog_args=None):
             print "Cannot get email attribute for user"
 
         try:
-            id = user[u'user_id']
+            identity = user[u'user_id']
         except (KeyError):
             print "Cannot get id attribute for user"
 
-        if id and email:
+        if identity and email:
             for domain in ldap_config['ldap_domains']:
                 if domain in email:
                     if get_ldap_user_by_mail(ldap_conn, email) is not True\
                             and email not in disable_deactivated_accounts_config['exclusion_list']:
                         print "Disabling Auth0 for %s" % email
                         if not opt.debug:
-                            disable_user(id)
+                            disable_user(identity)
 
 
 if __name__ == "__main__":

--- a/disable_deactivated_accounts.py
+++ b/disable_deactivated_accounts.py
@@ -26,7 +26,6 @@ def list_all_users():
     should_return = False
     return_list = []
     fetch_url = "%s/users" % auth0_config['auth0_api_url']
-#    payload = {'connection': "%s" % auth0_config['auth0_connection'], 'fields': 'user_id,email,blocked', 'include_fields': 'true'}
     payload = {'fields': 'identities,user_id,email,blocked', 'include_fields': 'true'}
     while (should_return is False):
         prev_url = fetch_url

--- a/disable_deactivated_accounts.py
+++ b/disable_deactivated_accounts.py
@@ -77,13 +77,19 @@ def get_ldap_user_by_mail(conn, mail):
                            ldap.SCOPE_SUBTREE,
                            '(&%s(!(%s)))' % (mail_query, disabled_query),
                            attrlist=['mail'])
-    try:
-        if member[0][1]['mail'][0]:
-            return True
-        else:
-            return False
-    except (IndexError, KeyError):
-        return None
+    if len(member) == 1:
+        try:
+            if member[0][1]['mail'][0]:
+                return True
+            else:
+                return False
+        except (IndexError, KeyError):
+            return None
+    elif len(members) == 0:
+        return False
+    else:
+        print "Something went wrong and we got %i entries and expected 0 or 1" % len(member)
+        sys.exit(2)
 
 # this function does the actual blocking of the user in auth0
 def disable_user(user_id):


### PR DESCRIPTION
Please review and check my logic on this. Before, the script would look at any auth0 accounts that came from the LDAP connection and then check whether they still exist in LDAP and block if not.

The new logic is instead to look at any accounts where the e-mail address is in our list of ldap-managed e-mail domains and if found, then first check if there's a canonical account that matches, if not, check for any aliases that match, finally if not found, then block the account in auth0.

This doesn't handle non-employee LDAP accounts at all, but I added the identities to the api call, so that can be parsed and added as a separate function. I want to get a review on what I have so far and make sure the logic is sound before proceeding.