### PR TITLE
Support for sending CIS-compatible v1 profiles (validated)

### DIFF
--- a/LDAP/ldap2s3/ldap2s3.py
+++ b/LDAP/ldap2s3/ldap2s3.py
@@ -194,6 +194,11 @@ class ldaper():
                      }
             user.PGPFingerprints.append(pgpkey)
 
+        # Phone numbers - note, its not in "telephoneNumber" which is only an extension for VOIP
+        phones = attrs.get('mobile')
+        for p in phones:
+            user.phoneNumbers.append(p.decode('utf-8'))
+
         # Names
         user.firstName = self.gfe(attrs, 'givenName')
         user.lastName = self.gfe(attrs, 'sn')
@@ -262,7 +267,7 @@ if __name__ == "__main__":
     sgen = mozldap.conn.extend.standard.paged_search(search_base=config.ldap.search_base.users,
                                                      search_filter=config.ldap.filter.users,
                                                      attributes = ['mail', 'sshPublicKey', 'pgpFingerprint', 'sn',
-                                                                   'givenName', 'workdayTimezone', 'telephoneNumber',
+                                                                   'givenName', 'mobile',
                                                                    'createTimestamp', 'modifyTimestamp'],
                                                      search_scope=SUBTREE, paged_size=10, generator=True)
     # Create the list of all users

--- a/LDAP/ldap2s3/ldap2s3.py
+++ b/LDAP/ldap2s3/ldap2s3.py
@@ -171,7 +171,7 @@ class ldaper():
         # Terrible hack to emulate the LDAP user_id
         # This NEEDS to match Auth0 LDAP user_ids
         # XXX Replace this by opaque UUIDs someday, as well as in the Auth0 LDAP Connector
-        user.userName = "{}".format(user.primaryEmail.split('@')[0])
+        user.userName = self.gfe(attrs, 'uid')
         user.user_id = "{}|{}".format(self.cis_config.user_id_prefix, user.userName)
 
         # SSH Key
@@ -267,7 +267,7 @@ if __name__ == "__main__":
     sgen = mozldap.conn.extend.standard.paged_search(search_base=config.ldap.search_base.users,
                                                      search_filter=config.ldap.filter.users,
                                                      attributes = ['mail', 'sshPublicKey', 'pgpFingerprint', 'sn',
-                                                                   'givenName', 'mobile',
+                                                                   'givenName', 'mobile', 'uid',
                                                                    'createTimestamp', 'modifyTimestamp'],
                                                      search_scope=SUBTREE, paged_size=10, generator=True)
     # Create the list of all users

--- a/LDAP/ldap2s3/ldap2s3.py
+++ b/LDAP/ldap2s3/ldap2s3.py
@@ -4,14 +4,14 @@
 import argparse
 import boto3
 from datetime import datetime
-import io
 import json
-from ldap3 import Server, Connection, ALL, SUBTREE
+from ldap3 import Server, Connection, SUBTREE
 import lzma
 import logging
 import os
 import yaml
 import sys
+import jsonschema
 
 # P2 compat
 try:
@@ -47,11 +47,25 @@ class DotDict(dict):
 
 
 class ldaper():
-    def __init__(self, uri, user, password):
+    def __init__(self, uri, user, password, cis_config):
         global logger
         # This could use the IAM profile eventually if we wanted, with schema validation
         # That said for now we only care about groups
-        self.userprofile = {'dn', 'email', 'groups'}
+
+        # Read the user profile in a string but don't parse it yet to avoid having
+        # To copy a bunch of dicts, which would cause MemoryError exceptions
+        profile_file = cis_config.skeleton
+        try:
+            with open(profile_file) as fd:
+                self.userprofile_json = fd.read()
+        except FileNotFoundError:
+            logger.critical("FATAL: Could not find default profile file: {}. Please check configuration."
+                            .format(profile_file))
+            sys.exit(127)
+            return # Not reached
+
+        self.cis_config = cis_config
+
         self.connect(uri, user, password)
 
     def connect(self, uri, user, password):
@@ -96,7 +110,7 @@ class ldaper():
         ret = []
         for s in sshlist:
             ss = s.decode('utf-8')
-            ret.append(ss.strip(' '))
+            ret.append(ss.strip(' ').strip('\r\n'))
 
         return ret
 
@@ -112,21 +126,89 @@ class ldaper():
 
         return ret
 
+    def validate_user(self, user_profile):
+        """
+        Validate a user profile against CIS profile
+        Returns True if the profile validate, False if not.
+        @user_profile: dict
+        """
+        schema_file = self.cis_config.schema
+        try:
+            with open(schema_file) as fd:
+                schema = json.load(fd)
+        except FileNotFoundError:
+            return False
+
+        try:
+            jsonschema.validate(user_profile, schema)
+            return True
+        except jsonschema.exceptions.ValidationError:
+            return False
+
     def user(self, entry):
         """
         Finds canonical LDAP data for that user
         """
-        user = DotDict(dict())
+        user = DotDict(json.loads(self.userprofile_json))
+
+        # Add LDAP attributes
         attrs = entry.get('raw_attributes')
-        user.mail = self.gfe(attrs, 'mail')
-        user.dn = self.gfe(entry, 'raw_dn')
-        if not user.mail or not user.dn:
-            logger.warning('Invalid user specification dn: {} mail: {}'.format(user.dn, user.mail))
+        dn = self.gfe(entry, 'raw_dn')
 
-        user.sshPublicKey = self.normalize_ssh(attrs.get('sshPublicKey'))
-        user.pgpFingerprint = self.normalize_pgp(attrs.get('pgpFingerprint'))
+        # Insert LDAP email as primary email
+        user.primaryEmail = self.gfe(attrs, 'mail')
+        email = {
+                  'value': user.primaryEmail,
+                  'verified': True,
+                  'primary': True,
+                  'name': 'LDAP-imported Email'
+                }
+        user.emails.append(email)
 
-        return user
+        if not user.primaryEmail or not dn:
+            logger.warning('Invalid user specification dn: {} mail: {}'.format(dn, user.primaryEmail))
+
+        # Terrible hack to emulate the LDAP user_id
+        # This NEEDS to match Auth0 LDAP user_ids
+        # XXX Replace this by opaque UUIDs someday, as well as in the Auth0 LDAP Connector
+        user.userName = "{}".format(user.primaryEmail.split('@')[0])
+        user.user_id = "{}|{}".format(self.cis_config.user_id_prefix, user.userName)
+
+        # SSH Key
+        for k in self.normalize_ssh(attrs.get('sshPublicKey')):
+            sshkey = {
+                      'value': k,
+                      'verified': False,
+                      'primary': True,
+                      'name': 'LDAP-imported SSH Public key'
+                     }
+            user.SSHFingerprints.append(sshkey)
+
+        # PGP Key
+        for k in self.normalize_pgp(attrs.get('pgpFingerprint')):
+            pgpkey = {
+                      'value': k,
+                      'verified': False,
+                      'primary': True,
+                      'name': 'LDAP-imported PGP Public key'
+                     }
+            user.PGPFingerprints.append(pgpkey)
+
+        # Names
+        user.firstName = self.gfe(attrs, 'givenName')
+        user.lastName = self.gfe(attrs, 'sn')
+        user.displayName = "{} {}".format(user.firstName, user.lastName)
+
+        # Times - Profile output format is 2017-03-09T21:28:51.851Z
+        dt = entry.get('attributes').get('createTimestamp')
+        created = dt.strftime('%Y-%m-%dT:%H:%M:%S.000Z')
+        user.created = created
+
+        dt = entry.get('attributes').get('modifyTimestamp')
+        lastModified = dt.strftime('%Y-%m-%dT:%H:%M:%S.000Z')
+        user.lastModified = lastModified
+
+        return (dn, user)
 
     def group(self, entry):
         # Note we cannot rely on the mail= part of the dn here, so we don't
@@ -163,7 +245,7 @@ if __name__ == "__main__":
         config = DotDict(yaml.load(fd))
 
 
-    mozldap = ldaper(config.ldap.uri, config.ldap.user, config.ldap.password)
+    mozldap = ldaper(config.ldap.uri, config.ldap.user, config.ldap.password, config.cis)
 
     # List all groups
     groups = {}
@@ -179,52 +261,39 @@ if __name__ == "__main__":
     users = {}
     sgen = mozldap.conn.extend.standard.paged_search(search_base=config.ldap.search_base.users,
                                                      search_filter=config.ldap.filter.users,
-                                                     attributes = ['mail', 'sshPublicKey', 'pgpFingerprint'],
+                                                     attributes = ['mail', 'sshPublicKey', 'pgpFingerprint', 'sn',
+                                                                   'givenName', 'workdayTimezone', 'telephoneNumber',
+                                                                   'createTimestamp', 'modifyTimestamp'],
                                                      search_scope=SUBTREE, paged_size=10, generator=True)
+    # Create the list of all users
     for entry in sgen:
-        u = mozldap.user(entry)
-        users[u.dn] = {'mail': u.mail, 'SSHFingerprints': u.sshPublicKey, 'PGPFingerprints': u.pgpFingerprint}
+        dn, u = mozldap.user(entry)
+        users[dn] = u
 
-    # Intersect all this to find which users belong to which group
-    # Users = {'dn here': 'mail value here', ...}
-    # Groups = {'group name here': ['dn here', ...], ...}
-
-    # Create the list of users per groups. We don't actually currently use this.
-#    grouplist = {}
-#    set_userskey = set(users.keys())
-#    for group in groups:
-#        uing = set(groups[group]) & set_userskey
-#        for u in uing:
-#            if not grouplist.get(group):
-#                grouplist[group] = []
-#            grouplist[group].append(users[u])
-
-    # Same but reverse (find which group belongs to which users). We actually use this ;-)
-    userlist = {}
-    # Prefill so that we include users with no group data and default other attributes
-    for u in users:
-        user = users[u]
-        useremail = user.get('mail')
-        userlist[useremail] = {'groups': [], 'SSHFingerprints': user.get('SSHFingerprints'), 'PGPFingerprints': user.get('PGPFingerprints')}
+    # Find which group belongs to which users and add them
     set_userskey = set(users.keys())
     for group in groups:
         uing = set(groups[group]) & set_userskey
         for u in uing:
-            useremail = users[u]['mail']
-            userlist[useremail]['groups'].append(group)
-
-    # Add user attributes
+            users[u]['groups'].append(group)
 
     logger.debug('Resulting group list:')
-    logger.debug(json.dumps(userlist))
-    userlist_json_str = json.dumps(userlist, ensure_ascii=False).encode('utf-8')
+    logger.debug(json.dumps(users))
+
+    # Validate all user profiles, warn strongly on failure
+    for u in users:
+        if not mozldap.validate_user(users[u]):
+            logger.critical("Profile schema validation failed for user {} - skipped".format(u))
+
+    # Flatten our list of users into a single json string
+    userlist_json_str = json.dumps(users, ensure_ascii=False).encode('utf-8')
 
     # Compare with cache
     changes_detected = True # Default to "we have changes" in case cache does not exist
     try:
         with open(config.aws.s3.cache, 'r') as fd:
             cached = json.load(fd)
-            if (sorted(cached.items()) == sorted(userlist.items())):
+            if (sorted(cached.items()) == sorted(users.items())):
                 logger.debug("No change detected since last run - won't upload to S3")
                 changes_detected = False
             else:
@@ -253,4 +322,4 @@ if __name__ == "__main__":
                 region_name=config.aws.boto.region)
         # We xz compress and send a single file as its vastly faster than sending one file per user (1000x faster)
         xz = lzma.compress(userlist_json_str)
-        s3.put_object(Bucket=config.aws.s3.bucket, Key="ldap.json.xz", Body=xz)
+        s3.put_object(Bucket=config.aws.s3.bucket, Key=config.aws.s3.filename, Body=xz)

--- a/LDAP/ldap2s3/ldap2s3.yml.example
+++ b/LDAP/ldap2s3/ldap2s3.yml.example
@@ -8,6 +8,10 @@ ldap:
     filter:
         groups: "(objectClass=groupOfNames)"
         users: "(&(!(employeeType=DISABLED))(objectClass=inetOrgPerson)(|(o:dn:=org)(o:dn:=com)(o:dn:=net)(ou:dn:=shared_accounts)))"
+cis:
+    schema: 'schema.json'
+    skeleton: 'profile.json'
+    user_id_prefix: 'ad|Mozilla-LDAP|'
 aws:
     boto:
         access_key_id: ""
@@ -15,4 +19,5 @@ aws:
         region: "us-west-2"
     s3:
         bucket: "dev-cis-ldap2s3-publisher-data"
+        filename: "ldap-full-profile.json.xz"
         cache: "/var/tmp/ldap2s3-cache.json"

--- a/LDAP/ldap2s3/ldap2s3.yml.example
+++ b/LDAP/ldap2s3/ldap2s3.yml.example
@@ -11,7 +11,7 @@ ldap:
 cis:
     schema: 'schema.json'
     skeleton: 'profile.json'
-    user_id_prefix: 'ad|Mozilla-LDAP|'
+    user_id_prefix: 'ad|Mozilla-LDAP'
 aws:
     boto:
         access_key_id: ""

--- a/LDAP/ldap2s3/profile.json
+++ b/LDAP/ldap2s3/profile.json
@@ -1,0 +1,31 @@
+{
+	"user_id": "",
+	"timezone": "",
+	"active": true,
+	"lastModified": "",
+	"created": "",
+	"userName": "",
+	"displayName": "",
+	"firstName": "",
+	"lastName": "",
+	"preferredLanguage": "",
+	"primaryEmail": "",
+	"emails": [
+	],
+	"phoneNumbers": [
+	],
+	"uris": [
+	],
+	"nicknames": [
+	],
+	"SSHFingerprints": [
+	],
+	"PGPFingerprints": [
+	],
+	"picture": "",
+	"shirtSize": "",
+	"groups": [
+	],
+	"authoritativeGroups": [
+	]
+}

--- a/LDAP/ldap2s3/requirements.txt
+++ b/LDAP/ldap2s3/requirements.txt
@@ -1,4 +1,12 @@
+boto3==1.7.4
+botocore==1.10.4
+docutils==0.14
+jmespath==0.9.3
 ldap3==2.4.1
 pyaml==17.12.1
 pyasn1==0.4.2
+python-dateutil==2.6.1
 PyYAML==3.12
+s3transfer==0.1.13
+six==1.11.0
+jsonschema==2.6.0

--- a/LDAP/ldap2s3/schema.json
+++ b/LDAP/ldap2s3/schema.json
@@ -1,0 +1,323 @@
+{
+    "title": "CIS User Profile",
+    "description": "A user profile for a user managed by CIS.  Objects of this type are generated from information provided by identity providers (IdP's).  See https://github.com/mozilla-iam/cis/blob/master/docs/Profiles.md for details.",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "user_id",
+        "timezone",
+        "active",
+        "lastModified",
+        "created",
+        "userName",
+        "displayName",
+        "firstName",
+        "lastName",
+        "preferredLanguage",
+        "primaryEmail",
+        "emails",
+        "phoneNumbers",
+        "uris",
+        "nicknames",
+        "SSHFingerprints",
+        "PGPFingerprints",
+        "picture",
+        "shirtSize",
+        "groups",
+        "authoritativeGroups"
+    ],
+    "properties": {
+        "user_id": {
+            "type": "string",
+            "description": "The unique user identifier. Profile consumers should not try to interpret this value in any way or display it to the user. The value is stable and can be used to identify a user across multiple sessions."
+        },
+        "timezone": {
+            "type": "string",
+            "description": "Preferred timezone name for this user's location, e.g., 'Europe/London'."
+        },
+        "active": {
+            "type": "boolean",
+            "description": "If false, all access for this user should be denied. Profile consumers MUST check this value and disregard the remainder of the profile if false."
+        },
+        "lastModified": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date of last profile modification"
+        },
+        "created": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date of profile creation"
+        },
+        "userName": {
+            "type": "string",
+            "description": "Human-readable login name or identifier for this user. For a unique identifier, use `user_id` instead."
+        },
+        "displayName": {
+            "type": "string",
+            "description": "Human-readable full name for this user"
+        },
+        "firstName": {
+            "type": "string",
+            "description": "Human-readable first name (surname) for this user"
+        },
+        "lastName": {
+            "type": "string",
+            "description": "Human-readable last (family) name for this user"
+        },
+        "preferredLanguage": {
+            "type": "string",
+            "description": "Preferred language for this user, as a locale code such as `en_US`"
+        },
+        "primaryEmail": {
+            "type": "string",
+            "format": "email",
+            "description": "The primary email address at which the user may be reached.  Profile consumers may use this email to communicate with the user, but should not use it as a stable identifier for the user."
+        },
+        "emails": {
+            "type": "array",
+            "description": "All email addresses associated with this user's profile. Order is undefined.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "string",
+                        "format": "email",
+                        "description": "The email address"
+                    },
+                    "verified": {
+                        "type": "boolean",
+                        "description": "If true, then there is some assurance (such as via a confirmation code) that this email address belongs to the user. Otherwise, the value is entirely user-supplied."
+                    },
+                    "primary": {
+                        "type": "boolean",
+                        "description": "If true, this is the user's primary email and thus matches `profile.primaryEmail`."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "This is a description of the email address usage, such as `GitHub` or `Personal`"
+                    }
+                },
+                "required": [
+                    "value",
+                    "verified",
+                    "primary",
+                    "name"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "phoneNumbers": {
+            "type": "array",
+            "description": "All phone numbers associated with this user's profile.  Order is undefined.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "string",
+                        "description": "The phone number. Format is undefined."
+                    },
+                    "verified": {
+                        "type": "boolean",
+                        "description": "If true, then there is some assurance (such as via a confirmation code) that this phone number belongs to the user. Otherwise, the value is entirely user-supplied."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "This is a description of the phone number usage, such as `Work` or `Mobile`"
+                    }
+                },
+                "required": [
+                    "value",
+                    "verified",
+                    "name"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "uris": {
+            "type": "array",
+            "description": "All URIs associated with this user's profile such as `irc://irc.mozilla.org/infosec` or `https://blog.example.net`. Order is undefined.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "string",
+                        "description": "The URI. Format is undefined."
+                    },
+                    "verified": {
+                        "type": "boolean",
+                         "description": "If true, then there is some assurance (such as via a confirmation code) that this URI belongs to the user. Otherwise, the value is entirely user-supplied."
+                    },
+                    "primary": {
+                        "type": "boolean",
+                        "description": "If true, this is the user's primary URI."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "This is a description of the URI usage, such as `Blog` or `IRC channel`"
+                    }
+                },
+                "required": [
+                    "value",
+                    "verified",
+                    "primary",
+                    "name"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "nicknames": {
+            "type": "array",
+            "description": "All nicknames associated with this user's profile such as `bob` or `mary`. Order is undefined.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "string",
+                        "description": "The nickname. Format is undefined."
+                    },
+                    "verified": {
+                        "type": "boolean",
+                        "description": "If true, then there is some assurance (such as via a confirmation code) that this nickname belongs to the user. Otherwise, the value is entirely user-supplied."
+                    },
+                    "primary": {
+                        "type": "boolean",
+                        "description": "If true, this is the user's primary nickname."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "This is a description of the nickname usage, such as `IRC` or `Slack`"
+                    }
+                },
+                "required": [
+                    "value",
+                    "verified",
+                    "primary",
+                    "name"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "SSHFingerprints": {
+            "type": "array",
+            "description": "All OpenSSH fingerprints associated with this user's profile. Order is undefined.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "string",
+                        "description": "The SSH fingerprint. Format is undefined."
+                    },
+                    "verified": {
+                        "type": "boolean",
+                        "description": "If true, then there is some assurance that this key belongs to the associated user.  Otherwise, the value is entirely user-supplied."
+                    },
+                    "primary": {
+                        "type": "boolean",
+                        "description": "If true, this is the user's primary SSH fingerprint."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The user-supplied name for this fingerprint."
+                    }
+                },
+                "required": [
+                    "value",
+                    "verified",
+                    "primary",
+                    "name"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "PGPFingerprints": {
+            "type": "array",
+            "description": "All PGP fingerprints associated with this user's profile such as `D8097934A92E4B4210368102FF8B7AC6154E3226`. Order is undefined.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "string",
+                        "description": "The full fingerprint as a hex string."
+                    },
+                    "verified": {
+                        "type": "boolean",
+                        "description": "If true, then there is some assurance that this key belongs to the associated user.  Otherwise, the value is entirely user-supplied."
+                    },
+                    "primary": {
+                        "type": "boolean",
+                        "description": "If true, this is the user's primary PGP key."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The user-supplied name for this key."
+                    }
+                },
+                "required": [
+                    "value",
+                    "verified",
+                    "primary",
+                    "name"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "picture": {
+            "type": "string",
+            "format": "uri",
+            "description": "The URL to an image representing this user."
+        },
+        "shirtSize": {
+            "type": "string",
+            "description": "Shirt size for this user. Format undefined."
+        },
+        "tags": {
+            "type": "array",
+            "description": "General information about user's tags stored in mozillians.org.",
+            "items": {
+                "type": "string"
+            }
+        },
+        "groups": {
+            "type": "array",
+            "description": "Informational group membership for the user. Non-prefixed groups are what is known as Mozilla LDAP groups. Groups prefixed by a provider name and underscore are provided by a specific group engine.\nFor example `providername_groupone` is provided by `providername`.\nThese groups are provided `as-is` and you should ensure it contains the members you expect. See https://github.com/mozilla-iam/cis/blob/master/docs/Profiles.md for details.",
+            "items": {
+                "type": "string"
+            }
+        },
+        "authoritativeGroups": {
+            "type": "array",
+            "description": "A highy reliable list of groups for which this user is a member. These groups are either machine generated and strongly verified to be correct through software, or follow a well-defined human process in order to be verified to be correct.\nThese groups may optionally be used by the access providers themselves to assert access and may take precedence over the RP's own group checks.  See https://github.com/mozilla-iam/cis/blob/master/docs/Profiles.md for details.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "created": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Date the user became a member of this group"
+                    },
+                    "lastUsed": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Date at which this group membership last granted access to a resource (generally, an RP) for the user. This may be used to automatically expire and deny access when the lastUsed attribute is older than 3 month, for example."
+                        },
+                    "name": {
+                        "type": "string",
+                        "description": "Name of the group."
+                        },
+                    "uuid": {
+                        "type": "string",
+                        "description": "Unique identifier for the authoritative group. Profile consumers should not try to interpret this value in any way."
+                    }
+                },
+                "required": [
+                    "created",
+                    "lastUsed",
+                    "name",
+                    "uuid"
+                ],
+                "additionalProperties": false
+            }
+        }
+    }
+}


### PR DESCRIPTION
This sends to a new default file on S3 and is not compatible with the
older file format (obviously)
New config variables ensue..
Notes:

- for v2 profile, it should hopefully be loaded from the schema URL and
cached
- empty skeleton could be dynamically generated from the schema
- when profiles fail to validate, a critical message is emitted but the
script does NOT stop @jdow <=let me know if this needs to fail/exit for you to notice

You can find a demo on dev of this at https://s3.console.aws.amazon.com/s3/object/dev-cis-ldap2s3-publisher-data/ldap-full-profile.json.xz?region=us-west-2&tab=overview