### PR TITLE
Add additional detector for python2

### DIFF
--- a/LDAP/ldap2s3/ldap2s3.py
+++ b/LDAP/ldap2s3/ldap2s3.py
@@ -21,7 +21,10 @@ import yaml
 import sys
 import jsonschema
 
-if python2_detected:
+try:
+    FileNotFoundError
+except NameError:
+    python2_detected = True
     FileNotFoundError = IOError
 
 


### PR DESCRIPTION
apparently lzma alone is not enough to determine python2 or python3 on centos7